### PR TITLE
Automatically and Programatically Apply Migrations On Startup If Flag Is Set

### DIFF
--- a/Program.cs
+++ b/Program.cs
@@ -85,6 +85,7 @@ namespace Faction.Core
           .Build();
       AutoMigrateSchema(host);
       ConfirmDbSetup(host);
+      Console.WriteLine("Starting faction server...");
       host.Start();
     }
 


### PR DESCRIPTION
Related Issue: https://github.com/FactionC2/Faction/issues/36

This PR modifies some core logic in the Program.cs file in order to automatically apply migrations. 

First, Migrations should be compiled into the Faction.Common assemby. A PR exists for this.

Second, the assemblyName for migrations was changed to reflect their location. The new assemblyName is 
```
string assemblyName = typeof(FactionDbContext).Assembly.FullName;
```

Third, after Entity Framework has been initialized, the application checks to see if it can talk to the database by attempting to run "SELECT 1". This is done because connectivity needs to be independently confirmed from the creation/setup of the database so that migrations can be applied before the config is setup. Initial connectivity is checked by "ConfirmDBReady" and the flow more or less goes like : 

```
1) Init Entity Framework
2) Check if Database is listening / receptive to queries
3) Apply migrations if flag is set
4) Check if Language exists to confirm database is configured "ConfirmDbSetup"
```

Fourth, the actual migration will only be performed if the "POSTGRES_AUTO_MIGRATE" value is set to 1. However, the AutoMigrateSchema method does do some sanity checks to prevent users who are attempting to apply the static migrations to a database or project where migrations were generated manually. This is a pseudo version check to make auto migrations a feature on new deployments, but not old. If faction finds the intial migration, which in the current PR is "20191019033321_Initial", it will allow the user to auto migrate. However, "20191019033321_Initial" is not found, it will exit with a helpful error message. Users have the option to force auto migrations on self-built databases by setting POSTGRES_AUTO_MIGRATE_FORCE to 1 but this is discouraged.

There is some room for cleanup / improvement in the current implementation, but I believe it does a good job of supporting the feature. Though, I'm not married to this particular implementation so please let me know if you see room for improvement. Thanks!